### PR TITLE
fix result error when take photo and press back key

### DIFF
--- a/galleryfinal/src/main/java/cn/finalteam/galleryfinal/PhotoBaseActivity.java
+++ b/galleryfinal/src/main/java/cn/finalteam/galleryfinal/PhotoBaseActivity.java
@@ -121,7 +121,7 @@ public abstract class PhotoBaseActivity extends Activity implements EasyPermissi
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         if ( requestCode == GalleryFinal.TAKE_REQUEST_CODE ) {
-            if (resultCode == RESULT_OK && mTakePhotoUri != null) {
+            if (data!=null && resultCode == RESULT_OK && mTakePhotoUri != null) {
                 final String path = mTakePhotoUri.getPath();
                 final PhotoInfo info = new PhotoInfo();
                 info.setPhotoId(Utils.getRandom(10000, 99999));


### PR DESCRIPTION
resuleCode is 0(RESULT_OK) when press back key,So use to determine whether
the data is empty to judge whether the success of the camera